### PR TITLE
#22-doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The backend requires specific environment variables to connect to **Google Cloud
 In one terminal, from the project root with the virtual environment active:
 
 ```bash
+cd backend
 uv run main.py
 ```
 


### PR DESCRIPTION
Updated REAME.md to include correct instructions to run main.py from the backend directory instead of the root. 

### Proposed fix

```
cd backend 
uv run main.py

```

instead of 

```
uv run main.py

```