### PR TITLE
Fix backend run instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ The backend requires specific environment variables to connect to **Google Cloud
 
 #### Backend (port 8000)
 
-In one terminal, from the project root with the virtual environment active:
+In one terminal, with the virtual environment active:
 
 ```bash
+cd backend
 uv run main.py
 ```
 


### PR DESCRIPTION
Fixes #22

Description:
The README contained incorrect instructions for running the backend application.
It suggested running the backend from the project root, but `main.py` is located
inside the `backend` directory.

Proposed Fix:
Updated the README to include changing into the `backend` directory before running
the backend application.
