### PR TITLE
docs(README): fix backend run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ The backend requires specific environment variables to connect to **Google Cloud
 
 #### Backend (port 8000)
 
-In one terminal, from the project root with the virtual environment active:
+In one terminal, with the virtual environment active:
 
 ```bash
+cd backend
 uv run main.py
 ```
 


### PR DESCRIPTION
Adds the missing `cd backend` step before running `uv run main.py`, since `main.py` is located inside the backend/ directory.

Fixes #22 