### PR TITLE
Fix empty retrieval and API error handling in chat responses

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -460,13 +460,24 @@ async def generate_final_response(state: AgentState) -> AgentState:
             "- datasets from EBRAINS \n"
         )
         return {**state, "final_response": response}
+    
     raw_results = state.get("final_results", [])
+    
+    # Handle empty retrieval results
+    if not raw_results:
+        return {**state, "final_response": "No matching datasets found. Try a different search query."}
+    
     start_number = state.get("__start_number__", 1)
     prev_text = state.get("__previous_text__", "")
     print(f"Generating response for {len(raw_results)} final results, start={start_number}, intents={intents}")
-    response = await call_gemini_for_final_synthesis(
-        state["effective_query"], raw_results, intents, start_number=start_number, previous_text=prev_text
-    )
+    
+    try:
+        response = await call_gemini_for_final_synthesis(
+            state["effective_query"], raw_results, intents, start_number=start_number, previous_text=prev_text
+        )
+    except Exception:
+        response = "Unable to process your request. Please try again."
+    
     return {**state, "final_response": response}
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -131,9 +131,9 @@ async def chat_endpoint(msg: ChatMessage):
             status_code=504,
             detail="Request timed out. Please try with a simpler query.",
         )
-    except Exception as e:
+    except Exception:
         return ChatResponse(
-            response=f"Error: {e}",
+            response="Something went wrong. Please try again.",
             metadata={"error": True, "session_id": msg.session_id},
         )
 


### PR DESCRIPTION
Fixes #15 

This PR improves chat robustness by:
- Returning a clear message when no retrieval results are found
- Handling LLM / API failures with a user-friendly fallback
- Avoiding exposure of internal error details

The changes are intentionally minimal and scoped to Issue #15.
