### PR TITLE
Troubleshoot the issue of missing backend instruction in README  ✔️

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ The backend requires specific environment variables to connect to **Google Cloud
 
 In one terminal, from the project root with the virtual environment active:
 
+
+```bash
+cd backend
+```
+
+
 ```bash
 uv run main.py
 ```


### PR DESCRIPTION
This pull request addresses a documentation GAP where backend setup and run instructions were missing .

--> 𝗣𝗥𝗢𝗕𝗟𝗘𝗠
Previously, contributors and new users had difficulty understanding:

- How to start the backend service
- Where the backend entry point is located
- Which command should be used to run the backend locally

-->  𝗦𝗢𝗟𝗨𝗧𝗜𝗢𝗡
This update improves the README by:

- Adding clear backend setup and run instructions
- Clarifying the backend directory structure
- Helping new contributors get the backend running without trial-and-error


--> Here is the Proof of my Work or Contribution in filling this gap .

<img width="1810" height="816" alt="before" src="https://github.com/user-attachments/assets/dad114be-ba79-44fd-b967-14a66e5ede33" />
<img width="1845" height="833" alt="after" src="https://github.com/user-attachments/assets/0de16426-6716-414f-aeec-8c6e4c75f909" />

Kindly Review my Pull request @QuantumByte-01 


