### PR TITLE
Fix backend run instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The backend requires specific environment variables to connect to **Google Cloud
 In one terminal, from the project root with the virtual environment active:
 
 ```bash
+cd backend
 uv run main.py
 ```
 


### PR DESCRIPTION
Fixed backend run instructions in README to run from the backend directory.
Before: uv run main.py was suggested from project root (incorrect)
After: Now README instructs to cd backend first, then run uv run main.py
