### PR TITLE
fix: add Python version upper bound to prevent 3.14 compatibility war…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "knowledgespaceagent"
 version = "0.1.0"
 description = "Assistant"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "aiohttp>=3.12.15",
     "bs4>=0.0.2",


### PR DESCRIPTION
##Fixes #42

## Summary  
Adds an upper bound to the Python version requirement to prevent installation on Python 3.14+, where `langchain-core` currently emits a Pydantic V1 deprecation warning.

## Problem  
When users run the project with Python 3.14.0, the following warning appears on every startup:
UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
from pydantic.v1.fields import FieldInfo as FieldInfoV1


The application still works, but the warning is noisy and indicates future incompatibility.

## Solution  
Updated `pyproject.toml`:
```toml
requires-python = ">=3.12,<3.14"
This prevents accidental installation on Python 3.14+ until dependencies (especially langchain-core) fully support Pydantic V2 / Python 3.14.

Benefits
Eliminates the deprecation warning for all users
Future-proofs the project
Clear signal of supported Python versions

