### PR TITLE
Docs: fix Windows virtual environment activation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ uv venv
 
 # Activate it:
 # On Windows (cmd):
- .venv/bin/activate
+  .venv\Scripts\activate
 
 ```
 


### PR DESCRIPTION
Fixes #52

Updates the Windows virtual environment activation command in README to use the correct path.
