### PR TITLE
Bound in-memory chat sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ The backend requires specific environment variables to connect to **Google Cloud
 | `BQ_DATASET_ID`     | BigQuery dataset ID                  | Dataset containing KnowledgeSpace metadata |
 | `INDEX_ENDPOINT_ID` | Vertex AI Vector Search endpoint     | ID of deployed vector index for RAG        |
 | `ELASTIC_BASE_URL`  | Elasticsearch base URL               | URL of the text search engine              |
+| `SESSION_MAX_COUNT` | Maximum in-memory chat sessions      | Defaults to `1000`                         |
+| `SESSION_TTL_SECONDS` | Inactive session eviction time     | Defaults to `3600`; set `0` to disable TTL |
+| `SESSION_HISTORY_LIMIT` | Messages retained per session    | Defaults to `20`                           |
+
+The backend keeps chat history and paginated search results in memory. Session
+LRU and TTL eviction bound that memory for long-running deployments.
 
 ---
 

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -526,6 +526,7 @@ class NeuroscienceAssistant:
         self.chat_history: OrderedDict[str, List[str]] = OrderedDict()
         self.session_memory: OrderedDict[str, Dict[str, Any]] = OrderedDict()
         self._session_last_seen: OrderedDict[str, float] = OrderedDict()
+        self._session_tokens: Dict[str, object] = {}
         self.graph = self._build_graph()
 
     def _build_graph(self):
@@ -545,6 +546,7 @@ class NeuroscienceAssistant:
         self.chat_history.pop(session_id, None)
         self.session_memory.pop(session_id, None)
         self._session_last_seen.pop(session_id, None)
+        self._session_tokens.pop(session_id, None)
 
     def _evict_expired_sessions(self, now: float):
         if self.session_ttl_seconds <= 0:
@@ -558,8 +560,7 @@ class NeuroscienceAssistant:
     def _evict_overflow_sessions(self):
         while len(self._session_last_seen) > self.max_sessions:
             session_id, _ = self._session_last_seen.popitem(last=False)
-            self.chat_history.pop(session_id, None)
-            self.session_memory.pop(session_id, None)
+            self._drop_session(session_id)
 
     def _touch_session(self, session_id: str):
         now = monotonic()
@@ -578,6 +579,20 @@ class NeuroscienceAssistant:
         if len(history) > self.history_limit:
             self.chat_history[session_id] = history[-self.history_limit:]
 
+    def _ensure_session(self, session_id: str):
+        self._touch_session(session_id)
+        if session_id not in self.chat_history:
+            self.chat_history[session_id] = []
+        if session_id not in self._session_tokens:
+            self._session_tokens[session_id] = object()
+
+    def _session_is_current(self, session_id: str, token: object) -> bool:
+        return (
+            self._session_tokens.get(session_id) is token
+            and session_id in self._session_last_seen
+            and session_id in self.chat_history
+        )
+
     def reset_session(self, session_id: str):
         self._drop_session(session_id)
 
@@ -586,9 +601,8 @@ class NeuroscienceAssistant:
         try:
             if reset:
                 self.reset_session(session_id)
-            self._touch_session(session_id)
-            if session_id not in self.chat_history:
-                self.chat_history[session_id] = []
+            self._ensure_session(session_id)
+            session_token = self._session_tokens[session_id]
 
             more_count = _is_more_query(query)
             mem = self.session_memory.get(session_id, {})
@@ -612,6 +626,9 @@ class NeuroscienceAssistant:
                     )
                 except Exception:
                     text = "Unable to process your request. Please try again."
+                if not self._session_is_current(session_id, session_token):
+                    return text
+                self._touch_session(session_id)
                 mem.update({
                     "page": page,
                     "page_size": page_size,
@@ -641,6 +658,9 @@ class NeuroscienceAssistant:
             final_state = await self.graph.ainvoke(initial_state)
             response_text = final_state.get("final_response", "I encountered an unexpected empty response.")
 
+            if not self._session_is_current(session_id, session_token):
+                return response_text
+            self._touch_session(session_id)
             self.session_memory[session_id] = {
                 "all_results": final_state.get("all_results", []),
                 "page": 1,

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -527,6 +527,7 @@ class NeuroscienceAssistant:
         self.session_memory: OrderedDict[str, Dict[str, Any]] = OrderedDict()
         self._session_last_seen: OrderedDict[str, float] = OrderedDict()
         self._session_tokens: Dict[str, object] = {}
+        self._session_active_counts: Dict[str, int] = {}
         self.graph = self._build_graph()
 
     def _build_graph(self):
@@ -548,6 +549,21 @@ class NeuroscienceAssistant:
         self._session_last_seen.pop(session_id, None)
         self._session_tokens.pop(session_id, None)
 
+    def _session_is_active(self, session_id: str) -> bool:
+        return self._session_active_counts.get(session_id, 0) > 0
+
+    def _reserve_session(self, session_id: str):
+        self._session_active_counts[session_id] = self._session_active_counts.get(session_id, 0) + 1
+
+    def _release_session(self, session_id: str):
+        count = self._session_active_counts.get(session_id, 0)
+        if count <= 1:
+            self._session_active_counts.pop(session_id, None)
+        else:
+            self._session_active_counts[session_id] = count - 1
+        self._evict_expired_sessions(monotonic())
+        self._evict_overflow_sessions()
+
     def _evict_expired_sessions(self, now: float):
         if self.session_ttl_seconds <= 0:
             return
@@ -555,12 +571,23 @@ class NeuroscienceAssistant:
         for session_id, last_seen in list(self._session_last_seen.items()):
             if last_seen >= cutoff:
                 break
+            if self._session_is_active(session_id):
+                continue
             self._drop_session(session_id)
 
-    def _evict_overflow_sessions(self):
+    def _evict_overflow_sessions(self, protected_session_id: Optional[str] = None):
         while len(self._session_last_seen) > self.max_sessions:
-            session_id, _ = self._session_last_seen.popitem(last=False)
-            self._drop_session(session_id)
+            evicted = False
+            for session_id in list(self._session_last_seen):
+                if session_id == protected_session_id:
+                    continue
+                if self._session_is_active(session_id):
+                    continue
+                self._drop_session(session_id)
+                evicted = True
+                break
+            if not evicted:
+                break
 
     def _touch_session(self, session_id: str):
         now = monotonic()
@@ -572,7 +599,7 @@ class NeuroscienceAssistant:
             self.chat_history.move_to_end(session_id)
         if session_id in self.session_memory:
             self.session_memory.move_to_end(session_id)
-        self._evict_overflow_sessions()
+        self._evict_overflow_sessions(protected_session_id=session_id)
 
     def _trim_history(self, session_id: str):
         history = self.chat_history[session_id]
@@ -603,78 +630,93 @@ class NeuroscienceAssistant:
                 self.reset_session(session_id)
             self._ensure_session(session_id)
             session_token = self._session_tokens[session_id]
+            self._reserve_session(session_id)
+            try:
+                more_count = _is_more_query(query)
+                mem = self.session_memory.get(session_id, {})
+                if more_count is not None or (
+                    query.strip().lower() in {"more", "next", "continue", "more please", "show more", "keep going"}
+                ):
+                    all_results = mem.get("all_results", [])
+                    if not all_results:
+                        return (
+                            "There are no earlier results to continue. "
+                            "Ask me for a dataset (e.g., 'human EEG BIDS')."
+                        )
+                    page_size = more_count or mem.get("page_size", 15)
+                    page = mem.get("page", 1) + 1
+                    start = (page - 1) * page_size
+                    batch = all_results[start:start + page_size]
+                    if not batch:
+                        return "You've reached the end of the results. Try refining the query."
+                    intents = mem.get("intents", [QueryIntent.DATA_DISCOVERY.value])
+                    effective_query = mem.get("effective_query", "")
+                    prev_text = mem.get("last_text", "")
 
-            more_count = _is_more_query(query)
-            mem = self.session_memory.get(session_id, {})
-            if more_count is not None or (query.strip().lower() in {"more", "next", "continue", "more please", "show more", "keep going"}):
-                all_results = mem.get("all_results", [])
-                if not all_results:
-                    return "There are no earlier results to continue. Ask me for a dataset (e.g., 'human EEG BIDS')."
-                page_size = more_count or mem.get("page_size", 15)
-                page = mem.get("page", 1) + 1
-                start = (page - 1) * page_size
-                batch = all_results[start:start + page_size]
-                if not batch:
-                    return "You've reached the end of the results. Try refining the query."
-                intents = mem.get("intents", [QueryIntent.DATA_DISCOVERY.value])
-                effective_query = mem.get("effective_query", "")
-                prev_text = mem.get("last_text", "")
-                
-                try:
-                    text = await call_gemini_for_final_synthesis(
-                        effective_query, batch, intents, start_number=start + 1, previous_text=prev_text
-                    )
-                except Exception:
-                    text = "Unable to process your request. Please try again."
-                if not self._session_is_current(session_id, session_token):
+                    try:
+                        text = await call_gemini_for_final_synthesis(
+                            effective_query,
+                            batch,
+                            intents,
+                            start_number=start + 1,
+                            previous_text=prev_text,
+                        )
+                    except Exception:
+                        text = "Unable to process your request. Please try again."
+                    if not self._session_is_current(session_id, session_token):
+                        return text
+                    self._touch_session(session_id)
+                    mem.update({
+                        "page": page,
+                        "page_size": page_size,
+                        "last_text": f"{prev_text}\n\n{text}"[-12000:],
+                    })
+                    self.session_memory[session_id] = mem
+                    self.session_memory.move_to_end(session_id)
+                    self.chat_history[session_id].extend([f"User: {query}", f"Assistant: {text}"])
+                    self._trim_history(session_id)
                     return text
+
+                initial_state: AgentState = {
+                    "session_id": session_id,
+                    "query": query,
+                    "history": self.chat_history[session_id][-10:],
+                    "keywords": [],
+                    "effective_query": "",
+                    "intents": [],
+                    "ks_results": [],
+                    "vector_results": [],
+                    "final_results": [],
+                    "all_results": [],
+                    "start_number": 1,
+                    "previous_text": "",
+                    "final_response": "",
+                }
+                final_state = await self.graph.ainvoke(initial_state)
+                response_text = final_state.get(
+                    "final_response",
+                    "I encountered an unexpected empty response.",
+                )
+
+                if not self._session_is_current(session_id, session_token):
+                    return response_text
                 self._touch_session(session_id)
-                mem.update({
-                    "page": page,
-                    "page_size": page_size,
-                    "last_text": f"{prev_text}\n\n{text}"[-12000:],
-                })
-                self.session_memory[session_id] = mem
+                self.session_memory[session_id] = {
+                    "all_results": final_state.get("all_results", []),
+                    "page": 1,
+                    "page_size": 15,
+                    "effective_query": final_state.get("effective_query", initial_state["query"]),
+                    "keywords": final_state.get("keywords", []),
+                    "intents": final_state.get("intents", [QueryIntent.DATA_DISCOVERY.value]),
+                    "last_text": response_text,
+                }
                 self.session_memory.move_to_end(session_id)
-                self.chat_history[session_id].extend([f"User: {query}", f"Assistant: {text}"])
+
+                self.chat_history[session_id].extend([f"User: {query}", f"Assistant: {response_text}"])
                 self._trim_history(session_id)
-                return text
-
-            initial_state: AgentState = {
-                "session_id": session_id,
-                "query": query,
-                "history": self.chat_history[session_id][-10:],
-                "keywords": [],
-                "effective_query": "",
-                "intents": [],
-                "ks_results": [],
-                "vector_results": [],
-                "final_results": [],
-                "all_results": [],
-                "start_number": 1,
-                "previous_text": "",
-                "final_response": "",
-            }
-            final_state = await self.graph.ainvoke(initial_state)
-            response_text = final_state.get("final_response", "I encountered an unexpected empty response.")
-
-            if not self._session_is_current(session_id, session_token):
                 return response_text
-            self._touch_session(session_id)
-            self.session_memory[session_id] = {
-                "all_results": final_state.get("all_results", []),
-                "page": 1,
-                "page_size": 15,
-                "effective_query": final_state.get("effective_query", initial_state["query"]),
-                "keywords": final_state.get("keywords", []),
-                "intents": final_state.get("intents", [QueryIntent.DATA_DISCOVERY.value]),
-                "last_text": response_text,
-            }
-            self.session_memory.move_to_end(session_id)
-
-            self.chat_history[session_id].extend([f"User: {query}", f"Assistant: {response_text}"])
-            self._trim_history(session_id)
-            return response_text
+            finally:
+                self._release_session(session_id)
         except Exception as e:
             logger.error("Error in handle_chat: %s", e)
             import traceback

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -3,7 +3,9 @@ import os
 import re
 import json
 import asyncio
+from collections import OrderedDict
 from enum import Enum
+from time import monotonic
 from typing import Dict, List, Optional, TypedDict, Any
 import logging
 
@@ -86,6 +88,21 @@ def _get_genai_client():
 
 FLASH_MODEL = os.getenv("GEMINI_FLASH_MODEL", "gemini-2.5-flash")
 FLASH_LITE_MODEL = os.getenv("GEMINI_FLASH_LITE_MODEL", "gemini-2.5-flash-lite")
+
+
+def _env_int_at_least(name: str, default: int, minimum: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    if value < minimum:
+        logger.warning("%s must be >= %s; using default %s", name, minimum, default)
+        return default
+    return value
 
 
 # Query intent/types 
@@ -503,8 +520,12 @@ async def generate_final_response(state: AgentState) -> AgentState:
 
 class NeuroscienceAssistant:
     def __init__(self):
-        self.chat_history: Dict[str, List[str]] = {}
-        self.session_memory: Dict[str, Dict[str, Any]] = {}
+        self.max_sessions = _env_int_at_least("SESSION_MAX_COUNT", 1000, 1)
+        self.session_ttl_seconds = _env_int_at_least("SESSION_TTL_SECONDS", 3600, 0)
+        self.history_limit = _env_int_at_least("SESSION_HISTORY_LIMIT", 20, 1)
+        self.chat_history: OrderedDict[str, List[str]] = OrderedDict()
+        self.session_memory: OrderedDict[str, Dict[str, Any]] = OrderedDict()
+        self._session_last_seen: OrderedDict[str, float] = OrderedDict()
         self.graph = self._build_graph()
 
     def _build_graph(self):
@@ -520,15 +541,52 @@ class NeuroscienceAssistant:
         workflow.add_edge("generate_response", END)
         return workflow.compile()
 
-    def reset_session(self, session_id: str):
+    def _drop_session(self, session_id: str):
         self.chat_history.pop(session_id, None)
         self.session_memory.pop(session_id, None)
+        self._session_last_seen.pop(session_id, None)
+
+    def _evict_expired_sessions(self, now: float):
+        if self.session_ttl_seconds <= 0:
+            return
+        cutoff = now - self.session_ttl_seconds
+        for session_id, last_seen in list(self._session_last_seen.items()):
+            if last_seen >= cutoff:
+                break
+            self._drop_session(session_id)
+
+    def _evict_overflow_sessions(self):
+        while len(self._session_last_seen) > self.max_sessions:
+            session_id, _ = self._session_last_seen.popitem(last=False)
+            self.chat_history.pop(session_id, None)
+            self.session_memory.pop(session_id, None)
+
+    def _touch_session(self, session_id: str):
+        now = monotonic()
+        self._evict_expired_sessions(now)
+        if session_id in self._session_last_seen:
+            self._session_last_seen.move_to_end(session_id)
+        self._session_last_seen[session_id] = now
+        if session_id in self.chat_history:
+            self.chat_history.move_to_end(session_id)
+        if session_id in self.session_memory:
+            self.session_memory.move_to_end(session_id)
+        self._evict_overflow_sessions()
+
+    def _trim_history(self, session_id: str):
+        history = self.chat_history[session_id]
+        if len(history) > self.history_limit:
+            self.chat_history[session_id] = history[-self.history_limit:]
+
+    def reset_session(self, session_id: str):
+        self._drop_session(session_id)
 
 
     async def handle_chat(self, session_id: str, query: str, reset: bool = False) -> str:
         try:
             if reset:
                 self.reset_session(session_id)
+            self._touch_session(session_id)
             if session_id not in self.chat_history:
                 self.chat_history[session_id] = []
 
@@ -560,9 +618,9 @@ class NeuroscienceAssistant:
                     "last_text": f"{prev_text}\n\n{text}"[-12000:],
                 })
                 self.session_memory[session_id] = mem
+                self.session_memory.move_to_end(session_id)
                 self.chat_history[session_id].extend([f"User: {query}", f"Assistant: {text}"])
-                if len(self.chat_history[session_id]) > 20:
-                    self.chat_history[session_id] = self.chat_history[session_id][-20:]
+                self._trim_history(session_id)
                 return text
 
             initial_state: AgentState = {
@@ -592,10 +650,10 @@ class NeuroscienceAssistant:
                 "intents": final_state.get("intents", [QueryIntent.DATA_DISCOVERY.value]),
                 "last_text": response_text,
             }
+            self.session_memory.move_to_end(session_id)
 
             self.chat_history[session_id].extend([f"User: {query}", f"Assistant: {response_text}"])
-            if len(self.chat_history[session_id]) > 20:
-                self.chat_history[session_id] = self.chat_history[session_id][-20:]
+            self._trim_history(session_id)
             return response_text
         except Exception as e:
             logger.error("Error in handle_chat: %s", e)

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,209 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "backend"
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+def _install_dependency_stubs():
+    graph_module = types.ModuleType("langgraph.graph")
+    graph_module.END = "__end__"
+
+    class StateGraph:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def add_node(self, *_args, **_kwargs):
+            pass
+
+        def set_entry_point(self, *_args, **_kwargs):
+            pass
+
+        def add_edge(self, *_args, **_kwargs):
+            pass
+
+        def compile(self):
+            class Graph:
+                async def ainvoke(self, state):
+                    return {**state, "final_response": "ok"}
+
+            return Graph()
+
+    graph_module.StateGraph = StateGraph
+    langgraph_module = types.ModuleType("langgraph")
+    langgraph_module.graph = graph_module
+    sys.modules.setdefault("langgraph", langgraph_module)
+    sys.modules.setdefault("langgraph.graph", graph_module)
+
+    google_module = types.ModuleType("google")
+    genai_module = types.ModuleType("google.genai")
+    genai_types_module = types.ModuleType("google.genai.types")
+    genai_module.Client = lambda *_args, **_kwargs: object()
+    genai_module.types = genai_types_module
+    google_module.genai = genai_module
+    sys.modules.setdefault("google", google_module)
+    sys.modules.setdefault("google.genai", genai_module)
+    sys.modules.setdefault("google.genai.types", genai_types_module)
+
+    search_module = types.ModuleType("ks_search_tool")
+    search_module.general_search = lambda *_args, **_kwargs: []
+    search_module.general_search_async = lambda *_args, **_kwargs: []
+    search_module.global_fuzzy_keyword_search = lambda *_args, **_kwargs: []
+    sys.modules.setdefault("ks_search_tool", search_module)
+
+    retrieval_module = types.ModuleType("retrieval")
+    retrieval_module.get_retriever = lambda *_args, **_kwargs: None
+    sys.modules.setdefault("retrieval", retrieval_module)
+
+
+_install_dependency_stubs()
+import agents  # noqa: E402
+
+
+class BlockingGraph:
+    def __init__(self, response_text):
+        self.response_text = response_text
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def ainvoke(self, state):
+        self.started.set()
+        await self.release.wait()
+        return {
+            **state,
+            "all_results": ["dataset"],
+            "effective_query": state["query"],
+            "final_response": self.response_text,
+            "intents": [agents.QueryIntent.DATA_DISCOVERY.value],
+            "keywords": ["dataset"],
+        }
+
+
+class BlockingSynthesis:
+    def __init__(self, response_text):
+        self.response_text = response_text
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def __call__(self, *_args, **_kwargs):
+        self.started.set()
+        await self.release.wait()
+        return self.response_text
+
+
+def test_active_session_is_not_evicted_before_response_is_recorded(monkeypatch):
+    monkeypatch.setenv("SESSION_MAX_COUNT", "1")
+    monkeypatch.setenv("SESSION_TTL_SECONDS", "3600")
+
+    async def run():
+        assistant = agents.NeuroscienceAssistant()
+        assistant.graph = BlockingGraph("held response")
+
+        task = asyncio.create_task(assistant.handle_chat("active", "find data"))
+        await assistant.graph.started.wait()
+
+        assistant._ensure_session("newer")
+        assert "active" in assistant._session_last_seen
+        assert "newer" in assistant._session_last_seen
+
+        assistant.graph.release.set()
+        assert await task == "held response"
+
+        assert assistant.chat_history["active"] == [
+            "User: find data",
+            "Assistant: held response",
+        ]
+        assert assistant.session_memory["active"]["last_text"] == "held response"
+        assert "active" not in assistant._session_active_counts
+        assert "newer" not in assistant._session_last_seen
+        assert "newer" not in assistant.chat_history
+
+    asyncio.run(run())
+
+
+def test_active_more_session_is_not_evicted_before_page_is_recorded(monkeypatch):
+    monkeypatch.setenv("SESSION_MAX_COUNT", "1")
+    monkeypatch.setenv("SESSION_TTL_SECONDS", "3600")
+
+    async def run():
+        assistant = agents.NeuroscienceAssistant()
+        synthesis = BlockingSynthesis("second page")
+        monkeypatch.setattr(agents, "call_gemini_for_final_synthesis", synthesis)
+
+        assistant._ensure_session("active")
+        assistant.session_memory["active"] = {
+            "all_results": ["first", "second"],
+            "page": 1,
+            "page_size": 1,
+            "effective_query": "find data",
+            "intents": [agents.QueryIntent.DATA_DISCOVERY.value],
+            "last_text": "first page",
+        }
+
+        task = asyncio.create_task(assistant.handle_chat("active", "more"))
+        await synthesis.started.wait()
+
+        assistant._ensure_session("newer")
+        assert "active" in assistant._session_last_seen
+        assert "newer" in assistant._session_last_seen
+
+        synthesis.release.set()
+        assert await task == "second page"
+
+        assert assistant.session_memory["active"]["page"] == 2
+        assert assistant.session_memory["active"]["last_text"].endswith("second page")
+        assert assistant.chat_history["active"] == [
+            "User: more",
+            "Assistant: second page",
+        ]
+        assert "active" not in assistant._session_active_counts
+        assert "newer" not in assistant._session_last_seen
+        assert "newer" not in assistant.chat_history
+
+    asyncio.run(run())
+
+
+def test_active_session_is_not_dropped_by_ttl_eviction_until_released(monkeypatch):
+    monkeypatch.setenv("SESSION_MAX_COUNT", "2")
+    monkeypatch.setenv("SESSION_TTL_SECONDS", "10")
+
+    assistant = agents.NeuroscienceAssistant()
+    assistant._ensure_session("active")
+    assistant._session_last_seen["active"] = 100.0
+    assistant._reserve_session("active")
+
+    assistant._evict_expired_sessions(now=111.0)
+    assert "active" in assistant._session_last_seen
+    assert "active" in assistant.chat_history
+
+    monkeypatch.setattr(agents, "monotonic", lambda: 111.0)
+    assistant._release_session("active")
+    assert "active" not in assistant._session_last_seen
+    assert "active" not in assistant.chat_history
+    assert "active" not in assistant._session_active_counts
+
+
+def test_reset_invalidates_in_flight_session_response(monkeypatch):
+    monkeypatch.setenv("SESSION_MAX_COUNT", "2")
+    monkeypatch.setenv("SESSION_TTL_SECONDS", "3600")
+
+    async def run():
+        assistant = agents.NeuroscienceAssistant()
+        assistant.graph = BlockingGraph("stale response")
+
+        task = asyncio.create_task(assistant.handle_chat("session", "find data"))
+        await assistant.graph.started.wait()
+        assistant.reset_session("session")
+
+        assistant.graph.release.set()
+        assert await task == "stale response"
+
+        assert "session" not in assistant.chat_history
+        assert "session" not in assistant.session_memory
+        assert "session" not in assistant._session_last_seen
+        assert "session" not in assistant._session_active_counts
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Closes #76.

Adds bounded in-memory session retention for long-running backend processes:

- tracks chat sessions with LRU ordering
- evicts inactive sessions after `SESSION_TTL_SECONDS`, default `3600`
- limits total sessions with `SESSION_MAX_COUNT`, default `1000`
- keeps the existing per-session chat history cap configurable through `SESSION_HISTORY_LIMIT`, default `20`
- preserves active in-flight chat sessions during TTL/LRU eviction and reset races
- documents the memory behavior and environment variables in the README

## Verification

- `python3 -m py_compile backend/agents.py backend/main.py tests/test_session_lifecycle.py`
- `/tmp/ksa-pr105-venv/bin/python -m pytest -q tests/test_session_lifecycle.py` -> 4 passed
- `git diff --check`
- Dependency-isolated session lifecycle coverage for LRU eviction, TTL eviction, active in-flight requests, reset invalidation, history trimming, and `more` pagination state
